### PR TITLE
Move lib versions to ext for easier management.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
-
 buildscript {
+    ext.kotlinVersion = '1.2.50'
+    ext.androidMavenGradlePluginVersion = '2.1'
+
     repositories {
         google()
         mavenCentral()
@@ -7,8 +9,27 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath "com.github.dcendents:android-maven-gradle-plugin:$rootProject.ext.androidMavenGradlePluginVersion"
     }
+}
+
+ext {
+    minSdkVersion = 21
+    targetSdkVersion = 26
+    compileSdkVersion = 27
+    buildToolsVersion = '27.0.3'
+
+    // Android support specific libs.
+    supportLibraryVersion = '27.1.1'
+
+    // MaterialChips.
+    picassoVersion = '2.71828'
+    roundedImageViewVersion = '2.3.0'
+    materialEditTextVersion = '2.1.4'
+
+    // Test libs.
+    jUnitVersion = '4.12'
+    androidSupportTestVersion = '1.0.2'
 }
 
 allprojects {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     flavorDimensions "dimension"
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 26
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 4
         versionName "1.2.0"
         setProperty("archivesBaseName", "android-material-chips-$versionName")
@@ -23,21 +23,21 @@ android {
 }
 
 dependencies {
-    implementation 'com.makeramen:roundedimageview:2.3.0'
-    implementation 'com.squareup.picasso:picasso:2.71828'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.rengwuxian.materialedittext:library:2.1.4'
+    implementation "com.makeramen:roundedimageview:$rootProject.ext.roundedImageViewVersion"
+    implementation "com.squareup.picasso:picasso:$rootProject.ext.picassoVersion"
+    implementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
+    implementation "com.rengwuxian.materialedittext:library:$rootProject.ext.materialEditTextVersion"
 
     // FIX: Fixes some other lib using v2.1.0 of this lib and causing support version mismatch.
     // Remove when updating libs as it might not be needed anymore.
-    implementation "com.android.support:exifinterface:27.1.1"
+    implementation "com.android.support:exifinterface:$rootProject.ext.supportLibraryVersion"
 
     // JUnit
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'junit:junit:4.12'
+    testImplementation "junit:junit:$rootProject.ext.jUnitVersion"
+    androidTestImplementation "junit:junit:$rootProject.ext.jUnitVersion"
     // Testing
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation "com.android.support.test:runner:$rootProject.ext.androidSupportTestVersion"
+    androidTestImplementation "com.android.support.test:rules:$rootProject.ext.androidSupportTestVersion"
 }
 
 task sourcesJar(type: Jar) {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     flavorDimensions "dimension"
 
     defaultConfig {
         applicationId "com.doodle.android.chips.sample"
-        minSdkVersion 16
-        targetSdkVersion 26
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 3
         versionName "1.2.0"
         setProperty("archivesBaseName", "android-material-chips-$versionName-sample")
@@ -25,9 +25,9 @@ android {
 dependencies {
     implementation project(':library')
 
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
-    implementation 'com.rengwuxian.materialedittext:library:2.1.4'
+    implementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"
+    implementation "com.rengwuxian.materialedittext:library:$rootProject.ext.materialEditTextVersion"
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation "junit:junit:$rootProject.ext.jUnitVersion"
 }


### PR DESCRIPTION
### Changes proposed in this pull request
Some libs may have been updated, most I just moved the version info into the root build.gradle for easier management.
(Individual projects can now update/change lib versions without having to affect/update/alter the submodules.)